### PR TITLE
SQLキャプチャ用CapturingDataProviderの実装

### DIFF
--- a/tools/VBAnalyzer.Tests/CaptureModelSerializationTests.cs
+++ b/tools/VBAnalyzer.Tests/CaptureModelSerializationTests.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using VBAnalyzer.Models;
+using Xunit;
+
+namespace VBAnalyzer.Tests;
+
+public class CaptureModelSerializationTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    [Fact]
+    public void CaptureSession_RoundTrip_PreservesAllFields()
+    {
+        var session = new CaptureSession
+        {
+            SessionId = "test-session-id",
+            Calls = new List<CapturedCall>
+            {
+                new()
+                {
+                    Timestamp = new DateTime(2026, 3, 29, 10, 0, 0),
+                    ExecuteMethod = "ExecuteScalar<Int32>",
+                    ProcedureName = "dbo.dnn_AddContentItem",
+                    Parameters = new List<CapturedParameter>
+                    {
+                        new() { Index = 0, Value = "Content", Type = "String" },
+                        new() { Index = 1, Value = 1, Type = "Int32" }
+                    },
+                    ReturnValue = 5
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(session, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<CaptureSession>(json, JsonOptions);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal(session.SessionId, deserialized.SessionId);
+        Assert.Single(deserialized.Calls);
+
+        var call = deserialized.Calls[0];
+        Assert.Equal("ExecuteScalar<Int32>", call.ExecuteMethod);
+        Assert.Equal("dbo.dnn_AddContentItem", call.ProcedureName);
+        Assert.Equal(2, call.Parameters.Count);
+        Assert.Equal(0, call.Parameters[0].Index);
+        Assert.Equal("Content", call.Parameters[0].Value?.ToString());
+        Assert.Equal("String", call.Parameters[0].Type);
+    }
+
+    [Fact]
+    public void CaptureSession_JsonFormat_MatchesExpectedSchema()
+    {
+        var session = new CaptureSession
+        {
+            SessionId = "uuid-test",
+            Calls = new List<CapturedCall>
+            {
+                new()
+                {
+                    Timestamp = new DateTime(2026, 3, 29, 10, 0, 0),
+                    ExecuteMethod = "ExecuteScalar<Int32>",
+                    ProcedureName = "dbo.dnn_AddContentItem",
+                    Parameters = new List<CapturedParameter>
+                    {
+                        new() { Index = 0, Value = "Content", Type = "String" },
+                        new() { Index = 1, Value = 1, Type = "Int32" }
+                    },
+                    ReturnValue = 5
+                }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(session, JsonOptions);
+
+        // Verify JSON contains expected camelCase property names
+        Assert.Contains("\"sessionId\"", json);
+        Assert.Contains("\"calls\"", json);
+        Assert.Contains("\"timestamp\"", json);
+        Assert.Contains("\"executeMethod\"", json);
+        Assert.Contains("\"procedureName\"", json);
+        Assert.Contains("\"parameters\"", json);
+        Assert.Contains("\"index\"", json);
+        Assert.Contains("\"value\"", json);
+        Assert.Contains("\"type\"", json);
+        Assert.Contains("\"returnValue\"", json);
+    }
+
+    [Fact]
+    public void CaptureSession_EmptySession_SerializesCorrectly()
+    {
+        var session = new CaptureSession
+        {
+            SessionId = "empty-session"
+        };
+
+        var json = JsonSerializer.Serialize(session, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<CaptureSession>(json, JsonOptions);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal("empty-session", deserialized.SessionId);
+        Assert.Empty(deserialized.Calls);
+    }
+
+    [Fact]
+    public void CapturedCall_NullReturnValue_SerializesAsNull()
+    {
+        var call = new CapturedCall
+        {
+            Timestamp = DateTime.Now,
+            ExecuteMethod = "ExecuteNonQuery",
+            ProcedureName = "dbo.dnn_DeleteContentItem",
+            ReturnValue = null
+        };
+
+        var json = JsonSerializer.Serialize(call, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<CapturedCall>(json, JsonOptions);
+
+        Assert.NotNull(deserialized);
+        Assert.Null(deserialized.ReturnValue);
+    }
+
+    [Fact]
+    public void CaptureSession_DefaultSessionId_IsValidGuid()
+    {
+        var session = new CaptureSession();
+
+        Assert.True(Guid.TryParse(session.SessionId, out _));
+    }
+}

--- a/tools/VBAnalyzer.Tests/CaptureSessionManagerTests.cs
+++ b/tools/VBAnalyzer.Tests/CaptureSessionManagerTests.cs
@@ -1,0 +1,214 @@
+using System.Data;
+using System.Text.Json;
+using VBAnalyzer.Capturing;
+using VBAnalyzer.Models;
+using Xunit;
+
+namespace VBAnalyzer.Tests;
+
+public class CaptureSessionManagerTests
+{
+    [Fact]
+    public void StartSession_CreatesNewSession()
+    {
+        var manager = new CaptureSessionManager();
+        var stub = new StubDataProvider();
+
+        var provider = manager.StartSession(stub);
+
+        Assert.True(manager.IsCapturing);
+        Assert.NotNull(manager.CurrentSession);
+        Assert.NotNull(provider);
+    }
+
+    [Fact]
+    public void StartSession_WithSessionId_UsesProvidedId()
+    {
+        var manager = new CaptureSessionManager();
+        var stub = new StubDataProvider();
+
+        manager.StartSession(stub, "test-id");
+
+        Assert.Equal("test-id", manager.CurrentSession!.SessionId);
+    }
+
+    [Fact]
+    public void StartSession_ThrowsIfAlreadyCapturing()
+    {
+        var manager = new CaptureSessionManager();
+        var stub = new StubDataProvider();
+
+        manager.StartSession(stub);
+
+        Assert.Throws<InvalidOperationException>(() => manager.StartSession(stub));
+    }
+
+    [Fact]
+    public void EndSession_ReturnsCapturedCalls()
+    {
+        var manager = new CaptureSessionManager();
+        var stub = new StubDataProvider();
+
+        var provider = manager.StartSession(stub, "session-1");
+        provider.ExecuteNonQuery("TestProc", 1);
+        provider.ExecuteScalar("CountProc");
+
+        var session = manager.EndSession();
+
+        Assert.Equal("session-1", session.SessionId);
+        Assert.Equal(2, session.Calls.Count);
+        Assert.False(manager.IsCapturing);
+    }
+
+    [Fact]
+    public void EndSession_ThrowsIfNotCapturing()
+    {
+        var manager = new CaptureSessionManager();
+
+        Assert.Throws<InvalidOperationException>(() => manager.EndSession());
+    }
+
+    [Fact]
+    public void ToJson_ProducesExpectedFormat()
+    {
+        var session = new CaptureSession
+        {
+            SessionId = "test-uuid",
+            Calls = new List<CapturedCall>
+            {
+                new()
+                {
+                    Timestamp = new DateTime(2026, 3, 29, 10, 0, 0),
+                    ExecuteMethod = "ExecuteScalar<Int32>",
+                    ProcedureName = "dbo.dnn_AddContentItem",
+                    Parameters = new List<CapturedParameter>
+                    {
+                        new() { Index = 0, Value = "Content", Type = "String" },
+                        new() { Index = 1, Value = 1, Type = "Int32" }
+                    },
+                    ReturnValue = 5
+                }
+            }
+        };
+
+        var json = CaptureSessionManager.ToJson(session);
+
+        Assert.Contains("\"sessionId\"", json);
+        Assert.Contains("test-uuid", json);
+        Assert.Contains("ExecuteScalar<Int32>", json);
+        Assert.Contains("dbo.dnn_AddContentItem", json);
+        Assert.Contains("\"returnValue\"", json);
+    }
+
+    [Fact]
+    public void SaveToFile_And_LoadFromFile_RoundTrip()
+    {
+        var session = new CaptureSession
+        {
+            SessionId = "file-test",
+            Calls = new List<CapturedCall>
+            {
+                new()
+                {
+                    Timestamp = new DateTime(2026, 3, 29, 10, 0, 0),
+                    ExecuteMethod = "ExecuteReader",
+                    ProcedureName = "dbo.dnn_GetUser",
+                    Parameters = new List<CapturedParameter>
+                    {
+                        new() { Index = 0, Value = 1, Type = "Int32" }
+                    }
+                }
+            }
+        };
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"capture_test_{Guid.NewGuid()}.json");
+        try
+        {
+            CaptureSessionManager.SaveToFile(session, tempFile);
+
+            Assert.True(File.Exists(tempFile));
+
+            var loaded = CaptureSessionManager.LoadFromFile(tempFile);
+
+            Assert.NotNull(loaded);
+            Assert.Equal("file-test", loaded.SessionId);
+            Assert.Single(loaded.Calls);
+            Assert.Equal("ExecuteReader", loaded.Calls[0].ExecuteMethod);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void SaveToFile_CreatesDirectoryIfNotExists()
+    {
+        var session = new CaptureSession { SessionId = "dir-test" };
+        var tempDir = Path.Combine(Path.GetTempPath(), $"capture_test_{Guid.NewGuid()}");
+        var tempFile = Path.Combine(tempDir, "output.json");
+
+        try
+        {
+            CaptureSessionManager.SaveToFile(session, tempFile);
+
+            Assert.True(Directory.Exists(tempDir));
+            Assert.True(File.Exists(tempFile));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void EndToEnd_CaptureAndSerialize()
+    {
+        var manager = new CaptureSessionManager();
+        var stub = new StubDataProvider();
+
+        var provider = manager.StartSession(stub, "e2e-test");
+
+        // Execute some operations
+        using (var reader = provider.ExecuteReader("GetItems", 1))
+        {
+            while (reader.Read()) { }
+        }
+        provider.ExecuteNonQuery("UpdateItem", 1, "Updated");
+        var count = provider.ExecuteScalar<int>("CountItems");
+
+        var session = manager.EndSession();
+        var json = CaptureSessionManager.ToJson(session);
+
+        // Verify JSON is valid and contains expected data
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("e2e-test", root.GetProperty("sessionId").GetString());
+        Assert.Equal(3, root.GetProperty("calls").GetArrayLength());
+    }
+
+    private class StubDataProvider : DataProvider
+    {
+        public override string ConnectionString => "test";
+        public override string DatabaseOwner => "dbo.";
+        public override string ObjectQualifier => "dnn_";
+
+        public override IDataReader ExecuteReader(string procedureName, params object[] commandParameters)
+        {
+            var table = new DataTable();
+            table.Columns.Add("Id", typeof(int));
+            table.Rows.Add(1);
+            return table.CreateDataReader();
+        }
+
+        public override void ExecuteNonQuery(string procedureName, params object[] commandParameters) { }
+        public override object ExecuteScalar(string procedureName, params object[] commandParameters) => 10;
+        public override T ExecuteScalar<T>(string procedureName, params object[] commandParameters)
+            => (T)Convert.ChangeType(ExecuteScalar(procedureName, commandParameters), typeof(T));
+        public override DataSet ExecuteDataSet(string procedureName, params object[] commandParameters) => new();
+        public override IDataReader ExecuteSQL(string sql) => new DataTable().CreateDataReader();
+        public override IDataReader ExecuteSQL(string sql, params IDataParameter[] commandParameters) => new DataTable().CreateDataReader();
+        public override string ExecuteScript(string script) => string.Empty;
+        public override string ExecuteScript(string script, bool useTransactions) => string.Empty;
+    }
+}

--- a/tools/VBAnalyzer.Tests/CapturingDataProviderTests.cs
+++ b/tools/VBAnalyzer.Tests/CapturingDataProviderTests.cs
@@ -1,0 +1,161 @@
+using System.Data;
+using VBAnalyzer.Capturing;
+using Xunit;
+
+namespace VBAnalyzer.Tests;
+
+public class CapturingDataProviderTests
+{
+    [Fact]
+    public void ExecuteReader_CapturesCallAndWrapsReader()
+    {
+        var stub = new StubDataProvider();
+        var provider = new CapturingDataProvider(stub);
+
+        using var reader = provider.ExecuteReader("GetUser", 1, "admin");
+
+        Assert.Single(provider.Calls);
+        var call = provider.Calls[0];
+        Assert.Equal("ExecuteReader", call.ExecuteMethod);
+        Assert.Equal("dbo.dnn_GetUser", call.ProcedureName);
+        Assert.Equal(2, call.Parameters.Count);
+        Assert.Equal(1, call.Parameters[0].Value);
+        Assert.Equal("Int32", call.Parameters[0].Type);
+        Assert.Equal("admin", call.Parameters[1].Value);
+
+        // Reader should still work
+        Assert.True(reader.Read());
+        Assert.Equal(42, reader.GetInt32(0));
+    }
+
+    [Fact]
+    public void ExecuteNonQuery_CapturesCall()
+    {
+        var stub = new StubDataProvider();
+        var provider = new CapturingDataProvider(stub);
+
+        provider.ExecuteNonQuery("DeleteUser", 1);
+
+        Assert.Single(provider.Calls);
+        var call = provider.Calls[0];
+        Assert.Equal("ExecuteNonQuery", call.ExecuteMethod);
+        Assert.Equal("dbo.dnn_DeleteUser", call.ProcedureName);
+        Assert.Single(call.Parameters);
+    }
+
+    [Fact]
+    public void ExecuteScalar_CapturesCallAndReturnValue()
+    {
+        var stub = new StubDataProvider();
+        var provider = new CapturingDataProvider(stub);
+
+        var result = provider.ExecuteScalar("CountUsers");
+
+        Assert.Equal(99, result);
+        Assert.Single(provider.Calls);
+        var call = provider.Calls[0];
+        Assert.Equal("ExecuteScalar", call.ExecuteMethod);
+        Assert.Equal(99, call.ReturnValue);
+    }
+
+    [Fact]
+    public void ExecuteScalarGeneric_CapturesCallWithTypeName()
+    {
+        var stub = new StubDataProvider();
+        var provider = new CapturingDataProvider(stub);
+
+        var result = provider.ExecuteScalar<int>("CountUsers");
+
+        Assert.Equal(99, result);
+        Assert.Single(provider.Calls);
+        Assert.Equal("ExecuteScalar<Int32>", provider.Calls[0].ExecuteMethod);
+    }
+
+    [Fact]
+    public void ExecuteSQL_CapturesCall()
+    {
+        var stub = new StubDataProvider();
+        var provider = new CapturingDataProvider(stub);
+
+        using var reader = provider.ExecuteSQL("SELECT 1");
+
+        Assert.Single(provider.Calls);
+        Assert.Equal("ExecuteSQL", provider.Calls[0].ExecuteMethod);
+        Assert.Equal("SELECT 1", provider.Calls[0].ProcedureName);
+    }
+
+    [Fact]
+    public void MultipleCalls_AllCaptured()
+    {
+        var stub = new StubDataProvider();
+        var provider = new CapturingDataProvider(stub);
+
+        provider.ExecuteNonQuery("Proc1");
+        provider.ExecuteNonQuery("Proc2");
+        provider.ExecuteScalar("Proc3");
+
+        Assert.Equal(3, provider.Calls.Count);
+    }
+
+    [Fact]
+    public void ExecuteReader_ResultSetsLinkedToCapturedCall()
+    {
+        var stub = new StubDataProvider();
+        var provider = new CapturingDataProvider(stub);
+
+        using var reader = provider.ExecuteReader("GetUser", 1);
+
+        // Read through the data to trigger capture
+        while (reader.Read()) { }
+
+        var call = provider.Calls[0];
+        Assert.Single(call.ResultSets);
+        Assert.Single(call.ResultSets[0].Rows);
+        Assert.Equal(42, call.ResultSets[0].Rows[0][0]);
+    }
+
+    /// <summary>
+    /// テスト用のスタブDataProvider実装。
+    /// </summary>
+    private class StubDataProvider : DataProvider
+    {
+        public override string ConnectionString => "test-connection";
+        public override string DatabaseOwner => "dbo.";
+        public override string ObjectQualifier => "dnn_";
+
+        public override IDataReader ExecuteReader(string procedureName, params object[] commandParameters)
+        {
+            var table = new DataTable();
+            table.Columns.Add("Id", typeof(int));
+            table.Rows.Add(42);
+            return table.CreateDataReader();
+        }
+
+        public override void ExecuteNonQuery(string procedureName, params object[] commandParameters) { }
+
+        public override object ExecuteScalar(string procedureName, params object[] commandParameters) => 99;
+
+        public override T ExecuteScalar<T>(string procedureName, params object[] commandParameters)
+        {
+            var result = ExecuteScalar(procedureName, commandParameters);
+            return (T)Convert.ChangeType(result, typeof(T));
+        }
+
+        public override DataSet ExecuteDataSet(string procedureName, params object[] commandParameters) => new();
+
+        public override IDataReader ExecuteSQL(string sql)
+        {
+            var table = new DataTable();
+            return table.CreateDataReader();
+        }
+
+        public override IDataReader ExecuteSQL(string sql, params IDataParameter[] commandParameters)
+        {
+            var table = new DataTable();
+            return table.CreateDataReader();
+        }
+
+        public override string ExecuteScript(string script) => string.Empty;
+        public override string ExecuteScript(string script, bool useTransactions) => string.Empty;
+    }
+}

--- a/tools/VBAnalyzer.Tests/CapturingDataReaderTests.cs
+++ b/tools/VBAnalyzer.Tests/CapturingDataReaderTests.cs
@@ -1,0 +1,132 @@
+using System.Data;
+using VBAnalyzer.Capturing;
+using Xunit;
+
+namespace VBAnalyzer.Tests;
+
+public class CapturingDataReaderTests
+{
+    [Fact]
+    public void Read_CapturesAllRows()
+    {
+        using var table = CreateTestTable();
+        using var inner = table.CreateDataReader();
+        using var reader = new CapturingDataReader(inner);
+
+        while (reader.Read()) { }
+
+        var rs = reader.ResultSets[0];
+        Assert.Equal(2, rs.Rows.Count);
+        Assert.Equal(1, rs.Rows[0][0]);
+        Assert.Equal("Alice", rs.Rows[0][1]);
+        Assert.Equal(2, rs.Rows[1][0]);
+        Assert.Equal("Bob", rs.Rows[1][1]);
+    }
+
+    [Fact]
+    public void Read_CapturesColumnNames()
+    {
+        using var table = CreateTestTable();
+        using var inner = table.CreateDataReader();
+        using var reader = new CapturingDataReader(inner);
+
+        reader.Read();
+
+        var rs = reader.ResultSets[0];
+        Assert.Equal(new[] { "Id", "Name" }, rs.ColumnNames);
+    }
+
+    [Fact]
+    public void Read_DelegatesValueAccessCorrectly()
+    {
+        using var table = CreateTestTable();
+        using var inner = table.CreateDataReader();
+        using var reader = new CapturingDataReader(inner);
+
+        reader.Read();
+
+        Assert.Equal(1, reader.GetInt32(0));
+        Assert.Equal("Alice", reader.GetString(1));
+        Assert.Equal(1, reader["Id"]);
+        Assert.Equal("Alice", reader["Name"]);
+        Assert.Equal(2, reader.FieldCount);
+        Assert.Equal("Id", reader.GetName(0));
+        Assert.Equal(1, reader.GetOrdinal("Name"));
+    }
+
+    [Fact]
+    public void Read_HandlesNullValues()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, DBNull.Value);
+
+        using var inner = table.CreateDataReader();
+        using var reader = new CapturingDataReader(inner);
+
+        reader.Read();
+
+        var rs = reader.ResultSets[0];
+        Assert.Null(rs.Rows[0][1]);
+        Assert.True(reader.IsDBNull(1));
+    }
+
+    [Fact]
+    public void NextResult_CapturesMultipleResultSets()
+    {
+        var table1 = CreateTestTable();
+        var table2 = new DataTable();
+        table2.Columns.Add("Total", typeof(int));
+        table2.Rows.Add(100);
+
+        var dataSet = new DataSet();
+        dataSet.Tables.Add(table1);
+        dataSet.Tables.Add(table2);
+
+        using var inner = dataSet.CreateDataReader();
+        using var reader = new CapturingDataReader(inner);
+
+        // Read first result set
+        while (reader.Read()) { }
+
+        // Move to second result set
+        Assert.True(reader.NextResult());
+        while (reader.Read()) { }
+
+        Assert.Equal(2, reader.ResultSets.Count);
+
+        var rs1 = reader.ResultSets[0];
+        Assert.Equal(new[] { "Id", "Name" }, rs1.ColumnNames);
+        Assert.Equal(2, rs1.Rows.Count);
+
+        var rs2 = reader.ResultSets[1];
+        Assert.Equal(new[] { "Total" }, rs2.ColumnNames);
+        Assert.Single(rs2.Rows);
+        Assert.Equal(100, rs2.Rows[0][0]);
+    }
+
+    [Fact]
+    public void EmptyResultSet_CapturesNoRows()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+
+        using var inner = table.CreateDataReader();
+        using var reader = new CapturingDataReader(inner);
+
+        Assert.False(reader.Read());
+        Assert.Single(reader.ResultSets);
+        Assert.Empty(reader.ResultSets[0].Rows);
+    }
+
+    private static DataTable CreateTestTable()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "Alice");
+        table.Rows.Add(2, "Bob");
+        return table;
+    }
+}

--- a/tools/VBAnalyzer.Tests/IntegrationTests.cs
+++ b/tools/VBAnalyzer.Tests/IntegrationTests.cs
@@ -1,0 +1,231 @@
+using System.Data;
+using System.Text.Json;
+using VBAnalyzer.Capturing;
+using VBAnalyzer.Models;
+using Xunit;
+
+namespace VBAnalyzer.Tests;
+
+/// <summary>
+/// ComponentFactory経由でのCapturingDataProvider注入と、
+/// DNN風コード呼び出しパターンの統合テスト。
+/// </summary>
+public class IntegrationTests : IDisposable
+{
+    public IntegrationTests()
+    {
+        ComponentFactory.Clear();
+    }
+
+    public void Dispose()
+    {
+        ComponentFactory.Clear();
+    }
+
+    [Fact]
+    public void ComponentFactory_RegisterAndResolve_DataProvider()
+    {
+        var stub = new FakeDataProvider();
+        var capturing = new CapturingDataProvider(stub);
+
+        ComponentFactory.RegisterComponentInstance<DataProvider>(capturing);
+
+        var resolved = ComponentFactory.GetComponent<DataProvider>();
+        Assert.Same(capturing, resolved);
+    }
+
+    [Fact]
+    public void ComponentFactory_TransparentInjection_ExistingCodeUnchanged()
+    {
+        var stub = new FakeDataProvider();
+        var capturing = new CapturingDataProvider(stub);
+        ComponentFactory.RegisterComponentInstance<DataProvider>(capturing);
+
+        // DNN風のコード：ComponentFactory経由でDataProviderを取得して使用
+        var provider = ComponentFactory.GetComponent<DataProvider>();
+        provider.ExecuteNonQuery("AddContentItem", "Test Content", 1, -1);
+
+        // キャプチャされていることを確認
+        var capturingProvider = (CapturingDataProvider)provider;
+        Assert.Single(capturingProvider.Calls);
+        Assert.Equal("dbo.dnn_AddContentItem", capturingProvider.Calls[0].ProcedureName);
+    }
+
+    [Fact]
+    public void Integration_AddContentItem_CapturesCorrectSqlCall()
+    {
+        var manager = new CaptureSessionManager();
+        var stub = new FakeDataProvider();
+        var capturing = manager.StartSession(stub, "integration-test-1");
+        ComponentFactory.RegisterComponentInstance<DataProvider>(capturing);
+
+        // DNN DataService.AddContentItem相当の呼び出しをシミュレート
+        var provider = ComponentFactory.GetComponent<DataProvider>();
+        var contentItemId = provider.ExecuteScalar<int>("AddContentItem",
+            "Test Content",   // Content
+            1,                // ContentTypeId
+            -1,               // TabId
+            -1,               // ModuleId
+            "Test Title",     // ContentTitle
+            "",               // ContentKey
+            true              // Indexed
+        );
+
+        var session = manager.EndSession();
+
+        Assert.Equal("integration-test-1", session.SessionId);
+        Assert.Single(session.Calls);
+
+        var call = session.Calls[0];
+        Assert.Equal("ExecuteScalar<Int32>", call.ExecuteMethod);
+        Assert.Equal("dbo.dnn_AddContentItem", call.ProcedureName);
+        Assert.Equal(7, call.Parameters.Count);
+        Assert.Equal("Test Content", call.Parameters[0].Value);
+        Assert.Equal("String", call.Parameters[0].Type);
+        Assert.Equal(1, call.Parameters[1].Value);
+        Assert.Equal("Int32", call.Parameters[1].Type);
+        Assert.Equal(42, call.ReturnValue);
+    }
+
+    [Fact]
+    public void Integration_ExecuteReader_ReaderConsumedNormally()
+    {
+        var manager = new CaptureSessionManager();
+        var stub = new FakeDataProvider();
+        var capturing = manager.StartSession(stub, "reader-test");
+        ComponentFactory.RegisterComponentInstance<DataProvider>(capturing);
+
+        var provider = ComponentFactory.GetComponent<DataProvider>();
+
+        // DNN CBO.FillCollection相当のパターンをシミュレート
+        var items = new List<Dictionary<string, object?>>();
+        using (var reader = provider.ExecuteReader("GetContentItems", 1))
+        {
+            while (reader.Read())
+            {
+                var item = new Dictionary<string, object?>();
+                for (var i = 0; i < reader.FieldCount; i++)
+                {
+                    item[reader.GetName(i)] = reader.IsDBNull(i) ? null : reader.GetValue(i);
+                }
+                items.Add(item);
+            }
+        }
+
+        // 実データが正しく読めていること
+        Assert.Equal(2, items.Count);
+        Assert.Equal(1, items[0]["ContentItemId"]);
+        Assert.Equal("Item1", items[0]["Content"]);
+
+        // キャプチャも正しく記録されていること
+        var session = manager.EndSession();
+        var call = session.Calls[0];
+        Assert.Equal("ExecuteReader", call.ExecuteMethod);
+        Assert.Equal(2, call.ResultSets[0].Rows.Count);
+        Assert.Equal(new[] { "ContentItemId", "Content" }, call.ResultSets[0].ColumnNames);
+    }
+
+    [Fact]
+    public void Integration_MultipleCallsSession_JsonOutput()
+    {
+        var manager = new CaptureSessionManager();
+        var stub = new FakeDataProvider();
+        var capturing = manager.StartSession(stub, "multi-call-test");
+        ComponentFactory.RegisterComponentInstance<DataProvider>(capturing);
+
+        var provider = ComponentFactory.GetComponent<DataProvider>();
+
+        // 複数の呼び出し
+        using (var reader = provider.ExecuteReader("GetContentItems", 1))
+        {
+            while (reader.Read()) { }
+        }
+        provider.ExecuteNonQuery("UpdateContentItem", 1, "Updated Content");
+        var count = provider.ExecuteScalar<int>("CountContentItems");
+
+        var session = manager.EndSession();
+        var json = CaptureSessionManager.ToJson(session);
+
+        // JSON出力の検証
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("multi-call-test", root.GetProperty("sessionId").GetString());
+
+        var calls = root.GetProperty("calls");
+        Assert.Equal(3, calls.GetArrayLength());
+
+        Assert.Equal("ExecuteReader", calls[0].GetProperty("executeMethod").GetString());
+        Assert.Equal("ExecuteNonQuery", calls[1].GetProperty("executeMethod").GetString());
+        Assert.Equal("ExecuteScalar<Int32>", calls[2].GetProperty("executeMethod").GetString());
+    }
+
+    [Fact]
+    public void Integration_SessionSaveAndLoad_RoundTrip()
+    {
+        var manager = new CaptureSessionManager();
+        var stub = new FakeDataProvider();
+        var capturing = manager.StartSession(stub, "file-roundtrip");
+
+        capturing.ExecuteNonQuery("TestProc", 1);
+        capturing.ExecuteScalar<int>("CountProc");
+
+        var session = manager.EndSession();
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"integration_test_{Guid.NewGuid()}.json");
+        try
+        {
+            CaptureSessionManager.SaveToFile(session, tempFile);
+            var loaded = CaptureSessionManager.LoadFromFile(tempFile);
+
+            Assert.NotNull(loaded);
+            Assert.Equal("file-roundtrip", loaded.SessionId);
+            Assert.Equal(2, loaded.Calls.Count);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    /// <summary>
+    /// DNN DataProviderのスタブ実装。
+    /// 実際のDBアクセスの代わりにインメモリDataTableを返す。
+    /// </summary>
+    private class FakeDataProvider : DataProvider
+    {
+        public override string ConnectionString => "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=DotNetNuke";
+        public override string DatabaseOwner => "dbo.";
+        public override string ObjectQualifier => "dnn_";
+
+        public override IDataReader ExecuteReader(string procedureName, params object[] commandParameters)
+        {
+            var table = new DataTable();
+            table.Columns.Add("ContentItemId", typeof(int));
+            table.Columns.Add("Content", typeof(string));
+            table.Rows.Add(1, "Item1");
+            table.Rows.Add(2, "Item2");
+            return table.CreateDataReader();
+        }
+
+        public override void ExecuteNonQuery(string procedureName, params object[] commandParameters) { }
+
+        public override object ExecuteScalar(string procedureName, params object[] commandParameters) => 42;
+
+        public override T ExecuteScalar<T>(string procedureName, params object[] commandParameters)
+        {
+            var result = ExecuteScalar(procedureName, commandParameters);
+            return (T)Convert.ChangeType(result, typeof(T));
+        }
+
+        public override DataSet ExecuteDataSet(string procedureName, params object[] commandParameters) => new();
+
+        public override IDataReader ExecuteSQL(string sql) => new DataTable().CreateDataReader();
+
+        public override IDataReader ExecuteSQL(string sql, params IDataParameter[] commandParameters)
+            => new DataTable().CreateDataReader();
+
+        public override string ExecuteScript(string script) => string.Empty;
+        public override string ExecuteScript(string script, bool useTransactions) => string.Empty;
+    }
+}

--- a/tools/VBAnalyzer.Tests/VBAnalyzer.Tests.csproj
+++ b/tools/VBAnalyzer.Tests/VBAnalyzer.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\VBAnalyzer\VBAnalyzer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/VBAnalyzer/Capturing/CaptureSessionManager.cs
+++ b/tools/VBAnalyzer/Capturing/CaptureSessionManager.cs
@@ -1,0 +1,99 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using VBAnalyzer.Models;
+
+namespace VBAnalyzer.Capturing;
+
+/// <summary>
+/// キャプチャセッションのライフサイクル管理とJSON出力を提供する。
+/// </summary>
+public class CaptureSessionManager
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    private CaptureSession? _currentSession;
+    private CapturingDataProvider? _provider;
+
+    public CaptureSession? CurrentSession => _currentSession;
+    public bool IsCapturing => _currentSession != null;
+
+    /// <summary>
+    /// 新しいキャプチャセッションを開始する。
+    /// </summary>
+    public CapturingDataProvider StartSession(DataProvider innerProvider)
+    {
+        if (_currentSession != null)
+            throw new InvalidOperationException("セッションが既に開始されています。EndSessionを呼び出してください。");
+
+        _currentSession = new CaptureSession();
+        _provider = new CapturingDataProvider(innerProvider);
+        return _provider;
+    }
+
+    /// <summary>
+    /// 指定したsessionIdで新しいキャプチャセッションを開始する。
+    /// </summary>
+    public CapturingDataProvider StartSession(DataProvider innerProvider, string sessionId)
+    {
+        if (_currentSession != null)
+            throw new InvalidOperationException("セッションが既に開始されています。EndSessionを呼び出してください。");
+
+        _currentSession = new CaptureSession { SessionId = sessionId };
+        _provider = new CapturingDataProvider(innerProvider);
+        return _provider;
+    }
+
+    /// <summary>
+    /// セッションを終了し、キャプチャ結果を返す。
+    /// </summary>
+    public CaptureSession EndSession()
+    {
+        if (_currentSession == null || _provider == null)
+            throw new InvalidOperationException("セッションが開始されていません。");
+
+        _currentSession.Calls = _provider.Calls.ToList();
+        var session = _currentSession;
+        _currentSession = null;
+        _provider = null;
+        return session;
+    }
+
+    /// <summary>
+    /// セッションをJSON文字列にシリアライズする。
+    /// </summary>
+    public static string ToJson(CaptureSession session)
+    {
+        return JsonSerializer.Serialize(session, JsonOptions);
+    }
+
+    /// <summary>
+    /// セッションをJSONファイルに書き出す。
+    /// </summary>
+    public static void SaveToFile(CaptureSession session, string filePath)
+    {
+        var directory = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = ToJson(session);
+        File.WriteAllText(filePath, json);
+    }
+
+    /// <summary>
+    /// JSONファイルからセッションを読み込む。
+    /// </summary>
+    public static CaptureSession? LoadFromFile(string filePath)
+    {
+        var json = File.ReadAllText(filePath);
+        return JsonSerializer.Deserialize<CaptureSession>(json, JsonOptions);
+    }
+}

--- a/tools/VBAnalyzer/Capturing/CapturingDataProvider.cs
+++ b/tools/VBAnalyzer/Capturing/CapturingDataProvider.cs
@@ -1,0 +1,152 @@
+using System.Data;
+using System.Data.Common;
+using VBAnalyzer.Models;
+
+namespace VBAnalyzer.Capturing;
+
+/// <summary>
+/// DataProviderをラップし、全Execute*呼び出しをCapturedCallとして記録するデコレータ。
+/// </summary>
+public class CapturingDataProvider : DataProvider
+{
+    private readonly DataProvider _inner;
+    private readonly List<CapturedCall> _calls = new();
+
+    public CapturingDataProvider(DataProvider inner)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    public IReadOnlyList<CapturedCall> Calls => _calls;
+
+    public override string ConnectionString => _inner.ConnectionString;
+    public override string DatabaseOwner => _inner.DatabaseOwner;
+    public override string ObjectQualifier => _inner.ObjectQualifier;
+
+    public override IDataReader ExecuteReader(string procedureName, params object[] commandParameters)
+    {
+        var call = CreateCall("ExecuteReader", procedureName, commandParameters);
+        var reader = _inner.ExecuteReader(procedureName, commandParameters);
+        var capturingReader = new CapturingDataReader(reader);
+        call.ResultSets = capturingReader.ResultSets;
+        _calls.Add(call);
+        return capturingReader;
+    }
+
+    public override void ExecuteNonQuery(string procedureName, params object[] commandParameters)
+    {
+        var call = CreateCall("ExecuteNonQuery", procedureName, commandParameters);
+        _inner.ExecuteNonQuery(procedureName, commandParameters);
+        _calls.Add(call);
+    }
+
+    public override object ExecuteScalar(string procedureName, params object[] commandParameters)
+    {
+        var call = CreateCall("ExecuteScalar", procedureName, commandParameters);
+        var result = _inner.ExecuteScalar(procedureName, commandParameters);
+        call.ReturnValue = result;
+        _calls.Add(call);
+        return result;
+    }
+
+    public override T ExecuteScalar<T>(string procedureName, params object[] commandParameters)
+    {
+        var call = CreateCall($"ExecuteScalar<{typeof(T).Name}>", procedureName, commandParameters);
+        var result = _inner.ExecuteScalar<T>(procedureName, commandParameters);
+        call.ReturnValue = result;
+        _calls.Add(call);
+        return result;
+    }
+
+    public override DataSet ExecuteDataSet(string procedureName, params object[] commandParameters)
+    {
+        var call = CreateCall("ExecuteDataSet", procedureName, commandParameters);
+        var result = _inner.ExecuteDataSet(procedureName, commandParameters);
+        _calls.Add(call);
+        return result;
+    }
+
+    public override IDataReader ExecuteSQL(string sql)
+    {
+        var call = new CapturedCall
+        {
+            Timestamp = DateTime.UtcNow,
+            ExecuteMethod = "ExecuteSQL",
+            ProcedureName = sql
+        };
+        var reader = _inner.ExecuteSQL(sql);
+        var capturingReader = new CapturingDataReader(reader);
+        call.ResultSets = capturingReader.ResultSets;
+        _calls.Add(call);
+        return capturingReader;
+    }
+
+    public override IDataReader ExecuteSQL(string sql, params IDataParameter[] commandParameters)
+    {
+        var call = new CapturedCall
+        {
+            Timestamp = DateTime.UtcNow,
+            ExecuteMethod = "ExecuteSQL",
+            ProcedureName = sql,
+            Parameters = commandParameters.Select((p, i) => new CapturedParameter
+            {
+                Index = i,
+                Value = p.Value,
+                Type = p.DbType.ToString()
+            }).ToList()
+        };
+        var reader = _inner.ExecuteSQL(sql, commandParameters);
+        var capturingReader = new CapturingDataReader(reader);
+        call.ResultSets = capturingReader.ResultSets;
+        _calls.Add(call);
+        return capturingReader;
+    }
+
+    public override string ExecuteScript(string script)
+    {
+        var call = new CapturedCall
+        {
+            Timestamp = DateTime.UtcNow,
+            ExecuteMethod = "ExecuteScript",
+            ProcedureName = script
+        };
+        var result = _inner.ExecuteScript(script);
+        call.ReturnValue = result;
+        _calls.Add(call);
+        return result;
+    }
+
+    public override string ExecuteScript(string script, bool useTransactions)
+    {
+        var call = new CapturedCall
+        {
+            Timestamp = DateTime.UtcNow,
+            ExecuteMethod = "ExecuteScript",
+            ProcedureName = script,
+            Parameters = new List<CapturedParameter>
+            {
+                new() { Index = 0, Value = useTransactions, Type = "Boolean" }
+            }
+        };
+        var result = _inner.ExecuteScript(script, useTransactions);
+        call.ReturnValue = result;
+        _calls.Add(call);
+        return result;
+    }
+
+    private CapturedCall CreateCall(string method, string procedureName, object[] parameters)
+    {
+        return new CapturedCall
+        {
+            Timestamp = DateTime.UtcNow,
+            ExecuteMethod = method,
+            ProcedureName = ResolveProcedureName(procedureName),
+            Parameters = parameters.Select((p, i) => new CapturedParameter
+            {
+                Index = i,
+                Value = p is DBNull ? null : p,
+                Type = p?.GetType().Name ?? "DBNull"
+            }).ToList()
+        };
+    }
+}

--- a/tools/VBAnalyzer/Capturing/CapturingDataReader.cs
+++ b/tools/VBAnalyzer/Capturing/CapturingDataReader.cs
@@ -1,0 +1,142 @@
+using System.Data;
+using VBAnalyzer.Models;
+
+namespace VBAnalyzer.Capturing;
+
+/// <summary>
+/// IDataReaderをラップし、読み取られた行・列を全てキャプチャするデコレータ。
+/// Forward-onlyセマンティクスを維持しつつ、結果セットを記録する。
+/// </summary>
+public class CapturingDataReader : IDataReader
+{
+    private readonly IDataReader _inner;
+    private readonly List<CapturedResultSet> _resultSets = new();
+    private CapturedResultSet _currentResultSet;
+    private bool _schemaInitialized;
+
+    public CapturingDataReader(IDataReader inner)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _currentResultSet = new CapturedResultSet();
+        _resultSets.Add(_currentResultSet);
+    }
+
+    public List<CapturedResultSet> ResultSets => _resultSets;
+
+    // --- IDataReader control flow ---
+
+    public bool Read()
+    {
+        var result = _inner.Read();
+        if (result)
+        {
+            EnsureSchema();
+            CaptureCurrentRow();
+        }
+        return result;
+    }
+
+    public bool NextResult()
+    {
+        var result = _inner.NextResult();
+        if (result)
+        {
+            _currentResultSet = new CapturedResultSet();
+            _resultSets.Add(_currentResultSet);
+            _schemaInitialized = false;
+        }
+        return result;
+    }
+
+    public void Close() => _inner.Close();
+
+    public void Dispose() => _inner.Dispose();
+
+    // --- Schema/metadata ---
+
+    public int FieldCount => _inner.FieldCount;
+
+    public string GetName(int i) => _inner.GetName(i);
+
+    public int GetOrdinal(string name) => _inner.GetOrdinal(name);
+
+    public string GetDataTypeName(int i) => _inner.GetDataTypeName(i);
+
+    public Type GetFieldType(int i) => _inner.GetFieldType(i);
+
+    public DataTable? GetSchemaTable() => _inner.GetSchemaTable();
+
+    public int Depth => _inner.Depth;
+
+    public bool IsClosed => _inner.IsClosed;
+
+    public int RecordsAffected => _inner.RecordsAffected;
+
+    // --- Value access (delegated) ---
+
+    public object this[int i] => _inner[i];
+
+    public object this[string name] => _inner[name];
+
+    public object GetValue(int i) => _inner.GetValue(i);
+
+    public int GetValues(object[] values) => _inner.GetValues(values);
+
+    public bool IsDBNull(int i) => _inner.IsDBNull(i);
+
+    public bool GetBoolean(int i) => _inner.GetBoolean(i);
+
+    public byte GetByte(int i) => _inner.GetByte(i);
+
+    public long GetBytes(int i, long fieldOffset, byte[]? buffer, int bufferoffset, int length)
+        => _inner.GetBytes(i, fieldOffset, buffer, bufferoffset, length);
+
+    public char GetChar(int i) => _inner.GetChar(i);
+
+    public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length)
+        => _inner.GetChars(i, fieldoffset, buffer, bufferoffset, length);
+
+    public Guid GetGuid(int i) => _inner.GetGuid(i);
+
+    public short GetInt16(int i) => _inner.GetInt16(i);
+
+    public int GetInt32(int i) => _inner.GetInt32(i);
+
+    public long GetInt64(int i) => _inner.GetInt64(i);
+
+    public float GetFloat(int i) => _inner.GetFloat(i);
+
+    public double GetDouble(int i) => _inner.GetDouble(i);
+
+    public string GetString(int i) => _inner.GetString(i);
+
+    public decimal GetDecimal(int i) => _inner.GetDecimal(i);
+
+    public DateTime GetDateTime(int i) => _inner.GetDateTime(i);
+
+    public IDataReader GetData(int i) => _inner.GetData(i);
+
+    // --- Private helpers ---
+
+    private void EnsureSchema()
+    {
+        if (_schemaInitialized) return;
+
+        for (var i = 0; i < _inner.FieldCount; i++)
+        {
+            _currentResultSet.ColumnNames.Add(_inner.GetName(i));
+        }
+        _schemaInitialized = true;
+    }
+
+    private void CaptureCurrentRow()
+    {
+        var row = new List<object?>(_inner.FieldCount);
+        for (var i = 0; i < _inner.FieldCount; i++)
+        {
+            var value = _inner.IsDBNull(i) ? null : _inner.GetValue(i);
+            row.Add(value);
+        }
+        _currentResultSet.Rows.Add(row);
+    }
+}

--- a/tools/VBAnalyzer/Capturing/ComponentFactory.cs
+++ b/tools/VBAnalyzer/Capturing/ComponentFactory.cs
@@ -1,0 +1,38 @@
+namespace VBAnalyzer.Capturing;
+
+/// <summary>
+/// DotNetNuke.ComponentModel.ComponentFactoryの簡易版。
+/// DataProviderインスタンスの登録と取得を提供する。
+/// </summary>
+public static class ComponentFactory
+{
+    private static readonly Dictionary<Type, object> _components = new();
+
+    /// <summary>
+    /// コンポーネントを登録する。
+    /// </summary>
+    public static void RegisterComponentInstance<T>(T instance) where T : class
+    {
+        _components[typeof(T)] = instance ?? throw new ArgumentNullException(nameof(instance));
+    }
+
+    /// <summary>
+    /// 登録されたコンポーネントを取得する。
+    /// </summary>
+    public static T GetComponent<T>() where T : class
+    {
+        if (_components.TryGetValue(typeof(T), out var component))
+        {
+            return (T)component;
+        }
+        throw new InvalidOperationException($"コンポーネント {typeof(T).Name} が登録されていません。");
+    }
+
+    /// <summary>
+    /// 登録を全てクリアする。テストのクリーンアップ用。
+    /// </summary>
+    public static void Clear()
+    {
+        _components.Clear();
+    }
+}

--- a/tools/VBAnalyzer/Capturing/DataProvider.cs
+++ b/tools/VBAnalyzer/Capturing/DataProvider.cs
@@ -1,0 +1,33 @@
+using System.Data;
+using System.Data.Common;
+
+namespace VBAnalyzer.Capturing;
+
+/// <summary>
+/// DotNetNuke.Data.DataProviderと同じシグネチャの抽象基底クラス。
+/// .NET 8環境でCapturingDataProviderのベースとして使用する。
+/// </summary>
+public abstract class DataProvider
+{
+    public abstract string ConnectionString { get; }
+    public abstract string DatabaseOwner { get; }
+    public abstract string ObjectQualifier { get; }
+
+    public abstract IDataReader ExecuteReader(string procedureName, params object[] commandParameters);
+    public abstract void ExecuteNonQuery(string procedureName, params object[] commandParameters);
+    public abstract object ExecuteScalar(string procedureName, params object[] commandParameters);
+    public abstract T ExecuteScalar<T>(string procedureName, params object[] commandParameters);
+    public abstract DataSet ExecuteDataSet(string procedureName, params object[] commandParameters);
+    public abstract IDataReader ExecuteSQL(string sql);
+    public abstract IDataReader ExecuteSQL(string sql, params IDataParameter[] commandParameters);
+    public abstract string ExecuteScript(string script);
+    public abstract string ExecuteScript(string script, bool useTransactions);
+
+    /// <summary>
+    /// プロシージャ名をDatabaseOwner + ObjectQualifier + ProcedureName形式に解決する。
+    /// </summary>
+    public string ResolveProcedureName(string procedureName)
+    {
+        return $"{DatabaseOwner}{ObjectQualifier}{procedureName}";
+    }
+}

--- a/tools/VBAnalyzer/Models/CaptureSession.cs
+++ b/tools/VBAnalyzer/Models/CaptureSession.cs
@@ -1,0 +1,7 @@
+namespace VBAnalyzer.Models;
+
+public class CaptureSession
+{
+    public string SessionId { get; set; } = Guid.NewGuid().ToString();
+    public List<CapturedCall> Calls { get; set; } = new();
+}

--- a/tools/VBAnalyzer/Models/CapturedCall.cs
+++ b/tools/VBAnalyzer/Models/CapturedCall.cs
@@ -7,4 +7,5 @@ public class CapturedCall
     public string ProcedureName { get; set; } = string.Empty;
     public List<CapturedParameter> Parameters { get; set; } = new();
     public object? ReturnValue { get; set; }
+    public List<CapturedResultSet> ResultSets { get; set; } = new();
 }

--- a/tools/VBAnalyzer/Models/CapturedCall.cs
+++ b/tools/VBAnalyzer/Models/CapturedCall.cs
@@ -1,0 +1,10 @@
+namespace VBAnalyzer.Models;
+
+public class CapturedCall
+{
+    public DateTime Timestamp { get; set; }
+    public string ExecuteMethod { get; set; } = string.Empty;
+    public string ProcedureName { get; set; } = string.Empty;
+    public List<CapturedParameter> Parameters { get; set; } = new();
+    public object? ReturnValue { get; set; }
+}

--- a/tools/VBAnalyzer/Models/CapturedParameter.cs
+++ b/tools/VBAnalyzer/Models/CapturedParameter.cs
@@ -1,0 +1,8 @@
+namespace VBAnalyzer.Models;
+
+public class CapturedParameter
+{
+    public int Index { get; set; }
+    public object? Value { get; set; }
+    public string Type { get; set; } = string.Empty;
+}

--- a/tools/VBAnalyzer/Models/CapturedResultSet.cs
+++ b/tools/VBAnalyzer/Models/CapturedResultSet.cs
@@ -1,0 +1,7 @@
+namespace VBAnalyzer.Models;
+
+public class CapturedResultSet
+{
+    public List<string> ColumnNames { get; set; } = new();
+    public List<List<object?>> Rows { get; set; } = new();
+}


### PR DESCRIPTION
## Summary
- Closes #2
- #12 キャプチャデータモデルの定義（CapturedCall, CapturedParameter, CaptureSession, CapturedResultSet）
- #13 CapturingDataReaderの実装（IDataReaderデコレータ、全行列キャプチャ、複数結果セット対応）
- #14 CapturingDataProviderの実装（DataProvider抽象基底 + デコレータ、全Execute*インターセプト）
- #15 JSON出力・セッション管理機能の実装（CaptureSessionManager、ファイル入出力）
- #16 ComponentFactory登録・統合テスト（透過的注入、AddContentItemパターン検証）

## Test plan
- [x] 全33テスト成功（`dotnet test tools/VBAnalyzer.Tests`）
- [x] コードレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)